### PR TITLE
Fix module names: remove spaces for consistency

### DIFF
--- a/public/modules/anti-cheat/Banned Items.json
+++ b/public/modules/anti-cheat/Banned Items.json
@@ -1,5 +1,5 @@
 {
-  "name": "Banned Items",
+  "name": "BannedItems",
   "author": "Mad",
   "supportedGames": ["all"],
   "versions": [

--- a/public/modules/economy/Buff manager.json
+++ b/public/modules/economy/Buff manager.json
@@ -1,5 +1,5 @@
 {
-  "name": "Buff manager",
+  "name": "BuffManager",
   "author": "limon",
   "supportedGames": ["7 Days to Die"],
   "versions": [


### PR DESCRIPTION
## Summary
- Changed "Buff manager" to "BuffManager" 
- Changed "Banned Items" to "BannedItems"

## Reason
All other modules in the repository use camelCase or PascalCase names without spaces. The spaces were causing routing issues and preventing the modules from showing up on the live site.

## Test plan
- [ ] Modules accessible at `/module/BuffManager` and `/module/BannedItems`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized module display names to CamelCase for consistency across the interface.
    * Anti-Cheat: “Banned Items” → “BannedItems”.
    * Economy: “Buff manager” → “BuffManager”.
  * Improves visual consistency and readability in module lists and settings.
  * No behavioral or functional changes; updates affect labels only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->