### PR TITLE
fix: use takaro-ci-bot for changelog workflow commits

### DIFF
--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -13,11 +13,18 @@ jobs:
   update-changelogs:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TAKARO_CI_APP_ID }}
+          private-key: ${{ secrets.TAKARO_CI_APP_PRIV_KEY }}
+
       - name: Checkout code with full history
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Need full git history for changelog generation
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -31,16 +38,28 @@ jobs:
       - name: Generate changelogs
         run: npm run generate:changelog
 
+      - name: Check if last commit was by CI bot
+        id: check_last_commit
+        run: |
+          LAST_COMMIT_AUTHOR=$(git log -1 --pretty=format:'%an')
+          if [ "$LAST_COMMIT_AUTHOR" = "takaro-ci-bot[bot]" ]; then
+            echo "skip_commit=true" >> $GITHUB_OUTPUT
+            echo "Last commit was by CI bot, skipping to prevent redundant commits"
+          else
+            echo "skip_commit=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check for changelog changes
         id: check_changes
+        if: steps.check_last_commit.outputs.skip_commit != 'true'
         run: |
           git diff --quiet data/changelogs.json data/changelog-raw.json || echo "has_changes=true" >> $GITHUB_OUTPUT
 
       - name: Commit and push changelog updates
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: steps.check_last_commit.outputs.skip_commit != 'true' && steps.check_changes.outputs.has_changes == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "takaro-ci-bot[bot]"
+          git config user.email "138661031+takaro-ci-bot[bot]@users.noreply.github.com"
           git add data/changelogs.json data/changelog-raw.json
           git commit -m "chore: update changelogs [skip ci]"
           git push


### PR DESCRIPTION
## Summary
- Fixes the changelog workflow to use takaro-ci-bot GitHub App token instead of GITHUB_TOKEN
- This enables the workflow to successfully commit and push changelog updates
- Adds safety check to prevent redundant commits

## Changes
- Added token generation step using `actions/create-github-app-token@v2`
- Updated checkout to use the generated token
- Changed git config from `github-actions[bot]` to `takaro-ci-bot[bot]`
- Added check to skip commits if last commit was already from CI bot

## Test plan
- [ ] Merge this PR
- [ ] Trigger the workflow by pushing module JSON changes
- [ ] Verify the workflow successfully commits changelog updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal CI/CD workflow automation with improved authentication handling and conditional changelog update logic to optimize build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->