### PR TITLE
feat: show all changelog entries with filtering

### DIFF
--- a/components/HomeContent.tsx
+++ b/components/HomeContent.tsx
@@ -45,7 +45,7 @@ export function HomeContent({ modules, changelogs }: HomeContentProps) {
 
           {/* Global Changelog Section - Prominently positioned at top */}
           {changelogs && changelogs.global.length > 0 && (
-            <GlobalChangelog changes={changelogs.global} limit={10} />
+            <GlobalChangelog changes={changelogs.global} />
           )}
 
           {modules.length > 0 ? (


### PR DESCRIPTION
## Summary
Display all 42 changelog entries instead of limiting to 10, with filtering options by category and new/updated status.

## Changes
- **Remove limit**: Show all changelog entries instead of just 10
- **Category filter**: Dropdown to filter by module category
- **Status filter**: Filter by "New Modules" or "Updates"  
- **Better UX**: Display "X of Y changes" count to show filtering results

## Before
- Only showed 10 most recent changes
- No filtering options

## After
- Shows all 42 entries in the changelog
- Filter by category: all, administration, anti-cheat, community-management, economy, events, integration, minigames, PvP
- Filter by status: all, new modules, updates
- Example: "15 of 42 changes" when filtered

## Screenshots
Users can now:
- See the complete module history
- Filter to specific categories they care about
- Distinguish between new modules and updates to existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dropdown filters for category and status to help users refine changelog items.
  * Removed previous item count limitation; all available changelog entries now display without restriction.
  * Updated section heading from "Recent Updates" to "Module Changelog" for better clarity.
  * Added helpful empty-state messaging when applied filter criteria match no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->