### PR TITLE
Add PvP Bet module for 7 Days to Die

### DIFF
--- a/public/modules/pvp-bet.json
+++ b/public/modules/pvp-bet.json
@@ -1,9 +1,7 @@
 {
   "name": "PvP Bet",
   "author": "Mad",
-  "supportedGames": [
-    "7 days to die"
-  ],
+  "supportedGames": ["7 days to die"],
   "versions": [
     {
       "tag": "latest",


### PR DESCRIPTION
This PR adds a new PvP Bet module that enables player-vs-player betting battles.

## Features

**Commands:**
- `/pvpbet [amount]` - Challenge another player to a PvP battle with currency bet
- `/pvpaccept` - Accept an active PvP bet challenge

**Gameplay Flow:**
1. Player creates a bet challenge with `/pvpbet [amount]`
2. Another player accepts with `/pvpaccept`
3. Both players are teleported to opposite corners of the PvP arena
4. Players are automatically set to PvP mode
5. When one player kills the other, winner gets the entire pot
6. PvP mode is automatically removed after the match

**Features:**
- Configurable minimum bet amount
- Configurable arena location (X/Z coordinates)
- 30-minute expiration on pending bets
- 20-minute expiration on active matches
- Leaderboard tracking PvP bet wins
- Optional Discord integration for leaderboard
- Bi-hourly announcements explaining the system
- Prevents players from having multiple pending bets
- Prevents accepting your own bet

**Configuration Required:**
- `xLocation`: X coordinate of PvP arena center
- `zLocation`: Z coordinate of PvP arena center
- `minimumBetAmount`: Minimum currency for bets (default: 100)
- `discordChannelId`: Optional Discord channel for leaderboard

**Dependencies:**
- Requires PrismaCore module for PvP mode functionality

Tested and working on 7 Days to Die server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a PvP betting module letting players wager on 1v1 matches.
  * Commands to create and accept bets with validation, balance checks, and match state management.
  * Automatic match resolution, pot payouts, and real-time leaderboard tracking.
  * Optional Discord leaderboard posting and updates.
  * New permission to enable PvP betting for appropriate users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->