### PR TITLE
fix: allow CI to pass for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,16 +82,18 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.prod
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   # E2E tests with Playwright
+  # Only run for non-fork PRs (forks can't push images to pull from)
   test:
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Only push Docker images when PR is from same repo (not forks)
- Skip E2E tests for fork PRs (they depend on pushed images)
- Fork PRs still run lint, typecheck, and build checks

## Problem
When contributors submit PRs from forks (like Mad's PR #186), the CI workflow fails with:
```
denied: installation not allowed to Write organization package
```

This is because GitHub doesn't grant write permissions to the package registry for fork PRs (for security reasons).

## Solution
- Conditionally push Docker images only for non-fork PRs and pushes to main
- Skip E2E tests for fork PRs since they require the pushed image
- All quality checks (lint, typecheck, format, build) still run for fork PRs

## Test plan
- [ ] Merge this PR first
- [ ] Re-run Mad's PR #186 CI - it should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated CI/CD workflow to restrict Docker image builds and pushes to non-pull request scenarios and pull requests from the main repository
* Added conditional gating for end-to-end tests to execute only on non-fork pull requests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->