### PR TITLE
fix: update community module lobbyandback

### DIFF
--- a/public/modules/community-management/lobbyandback.json
+++ b/public/modules/community-management/lobbyandback.json
@@ -5,24 +5,24 @@
   "versions": [
     {
       "tag": "latest",
-      "description": "Adds /back (single-use: deletes saved location after teleport) and /lobby (teleport to fixed 0,40,0). /lobby saves your previous position so /back works once.",
-      "configSchema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{}}",
+      "description": "Adds /back (single-use: deletes saved location after teleport) and /lobby location set in user config. /lobby saves your previous position so /back works once.",
+      "configSchema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"lobbyX\":{\"type\":\"number\",\"title\":\"Lobby X\",\"description\":\"X coordinate for the lobby teleport location.\",\"default\":810},\"lobbyY\":{\"type\":\"number\",\"title\":\"Lobby Y\",\"description\":\"Y coordinate for the lobby teleport location.\",\"default\":28},\"lobbyZ\":{\"type\":\"number\",\"title\":\"Lobby Z\",\"description\":\"Z coordinate for the lobby teleport location.\",\"default\":626}},\"required\":[\"lobbyX\",\"lobbyY\",\"lobbyZ\"],\"additionalProperties\":false}",
       "uiSchema": "{}",
       "commands": [
-        {
-          "function": "// commands/lobby.js\nimport { takaro, data, checkPermission, TakaroUserError } from '@takaro/helpers';\n\nasync function main() {\n  const { pog, gameServerId, module: mod } = data;\n\n  if (!checkPermission(pog, 'LOBBY_TELEPORT_USE')) {\n    throw new TakaroUserError('You do not have permission to use lobby teleport.');\n  }\n\n  // Fixed coordinates (no config/userconfig)\n  const X = -1058, Y = 38, Z = 308;\n\n  // Save current spot for /back (single-use)\n  const previousLocation = { x: pog.positionX, y: pog.positionY, z: pog.positionZ, timestamp: new Date().toISOString() };\n  const existing = await takaro.variable.variableControllerSearch({\n    filters: { key: ['back_location'], gameServerId: [gameServerId], playerId: [pog.playerId], moduleId: [mod.moduleId] },\n  });\n  if (existing.data.data.length) {\n    await takaro.variable.variableControllerUpdate(existing.data.data[0].id, { value: JSON.stringify(previousLocation) });\n  } else {\n    await takaro.variable.variableControllerCreate({\n      key: 'back_location',\n      value: JSON.stringify(previousLocation),\n      gameServerId,\n      moduleId: mod.moduleId,\n      playerId: pog.playerId,\n    });\n  }\n\n  // Teleport to fixed lobby coords\n  await takaro.gameserver.gameServerControllerTeleportPlayer(gameServerId, pog.playerId, { x: X, y: Y, z: Z });\n  await data.player.pm(`Teleported to the lobby (X: ${X}, Y: ${Y}, Z: ${Z}). Use /back to return once.`);\n}\n\nawait main();",
-          "name": "lobby",
-          "description": "Teleport to the fixed lobby coordinates (0,40,0) and save your current spot for a single-use /back.",
-          "trigger": "lobby",
-          "helpText": "Teleports you to (0,40,0) and saves your current spot for a single-use /back.",
-          "arguments": []
-        },
         {
           "function": "// commands/back.js\nimport { takaro, data, checkPermission, TakaroUserError } from '@takaro/helpers';\n\nasync function main() {\n  const { pog, gameServerId, module: mod } = data;\n\n  if (!checkPermission(pog, 'BACK_TELEPORT_USE')) {\n    throw new TakaroUserError('You do not have permission to use back teleport.');\n  }\n\n  // Find saved back location\n  const search = await takaro.variable.variableControllerSearch({\n    filters: { key: ['back_location'], gameServerId: [gameServerId], playerId: [pog.playerId], moduleId: [mod.moduleId] },\n  });\n\n  if (search.data.data.length === 0) {\n    throw new TakaroUserError('No previous location found. Use /lobby first or another command that saves one.');\n  }\n\n  const v = search.data.data[0];\n  let backLocation;\n  try {\n    backLocation = JSON.parse(v.value);\n  } catch (_) {\n    throw new TakaroUserError('Saved back location is unreadable. Try saving again (e.g., use /lobby).');\n  }\n\n  // Teleport back\n  await takaro.gameserver.gameServerControllerTeleportPlayer(gameServerId, pog.playerId, {\n    x: backLocation.x, y: backLocation.y, z: backLocation.z,\n  });\n\n  // SINGLE-USE: delete the saved location after successful teleport\n  await takaro.variable.variableControllerDelete(v.id);\n\n  await data.player.pm('Teleported back to your previous location! (Single-use: location cleared.)');\n}\n\nawait main();",
           "name": "back",
           "description": "Teleport back to your previously saved location (single-use).",
           "trigger": "back",
           "helpText": "Teleports you back once to your last saved spot. After use, the saved spot is deleted.",
+          "arguments": []
+        },
+        {
+          "function": "import { takaro, data, checkPermission, TakaroUserError } from '@takaro/helpers';\n\nasync function main() {\n  const { pog, gameServerId, module: mod, player } = data;\n\n  if (!checkPermission(pog, 'LOBBY_TELEPORT_USE')) {\n    throw new TakaroUserError('You do not have permission to use lobby teleport.');\n  }\n\n  const X = mod.userConfig.lobbyX;\n  const Y = mod.userConfig.lobbyY;\n  const Z = mod.userConfig.lobbyZ;\n\n  if (\n    typeof X !== 'number' ||\n    typeof Y !== 'number' ||\n    typeof Z !== 'number'\n  ) {\n    throw new TakaroUserError('Lobby coordinates are not configured correctly.');\n  }\n\n  // Save current spot for /back (single-use)\n  const previousLocation = {\n    x: pog.positionX,\n    y: pog.positionY,\n    z: pog.positionZ,\n    timestamp: new Date().toISOString(),\n  };\n\n  const existing = await takaro.variable.variableControllerSearch({\n    filters: {\n      key: ['back_location'],\n      gameServerId: [gameServerId],\n      playerId: [pog.playerId],\n      moduleId: [mod.moduleId],\n    },\n  });\n\n  if (existing.data.data.length) {\n    await takaro.variable.variableControllerUpdate(existing.data.data[0].id, {\n      value: JSON.stringify(previousLocation),\n    });\n  } else {\n    await takaro.variable.variableControllerCreate({\n      key: 'back_location',\n      value: JSON.stringify(previousLocation),\n      gameServerId,\n      moduleId: mod.moduleId,\n      playerId: pog.playerId,\n    });\n  }\n\n  await takaro.gameserver.gameServerControllerTeleportPlayer(\n    gameServerId,\n    pog.playerId,\n    { x: X, y: Y, z: Z }\n  );\n\n  await player.pm(\n    `Teleported to the lobby (X: ${X}, Y: ${Y}, Z: ${Z}). Use /back to return once.`\n  );\n}\n\nawait main();",
+          "name": "lobby",
+          "description": "Teleport to the fixed lobby coordinates (0,40,0) and save your current spot for a single-use /back.",
+          "trigger": "lobby",
+          "helpText": "Teleports you to user config location and saves your current spot for a single-use /back.",
           "arguments": []
         }
       ],
@@ -45,5 +45,5 @@
       ]
     }
   ],
-  "takaroVersion": "v0.4.10"
+  "takaroVersion": "0.4.17"
 }


### PR DESCRIPTION
## Summary
- update the existing `public/modules/community-management/lobbyandback.json` module in place
- replace the hard-coded lobby coordinates with user-configurable `lobbyX`, `lobbyY`, and `lobbyZ`
- keep the stable repo filename/module identifier (`lobbyandback`) instead of introducing a second module entry

## Why in-place update
- the submitted JSON matches the existing module intent, commands, and permissions (`/lobby`, `/back`)
- author context says this should replace the old module, not sit beside it as a duplicate
- keeping the existing repo path avoids fragmenting changelogs/routes/module identity

## Validation
- submission JSON parsed cleanly
- embedded `configSchema` and `uiSchema` validated as JSON strings
- no blocked runtime patterns detected by the submission validator
- normalized only the repo-facing identifier/path decision; module behavior changes are from the submission itself

## Local checks run
- `node scripts/generate-version.js`
- `npm run format:check`
- `npm run lint` (repo has pre-existing warnings)
- `npm run typecheck`
- `npm run build`

## Notes
- category: `community-management`
- existing module triggers/permissions match the prior repo module, which is why this is handled as an update/replacement rather than a new module
