### PR TITLE
Fix module clicks for safe module names

### DIFF
--- a/public/modules/community-management/community-fund.json
+++ b/public/modules/community-management/community-fund.json
@@ -1,6 +1,6 @@
 {
   "takaroVersion": "0.0.0",
-  "name": "Community Fund",
+  "name": "community-fund",
   "author": "Takaro",
   "supportedGames": ["All Games"],
   "versions": [

--- a/public/modules/community-management/referral-program.json
+++ b/public/modules/community-management/referral-program.json
@@ -1,6 +1,6 @@
 {
   "takaroVersion": "0.0.0",
-  "name": "Referral Program",
+  "name": "referral-program",
   "author": "Takaro",
   "supportedGames": ["All Games"],
   "versions": [

--- a/public/modules/economy/PlaytimeBuffRewards.json
+++ b/public/modules/economy/PlaytimeBuffRewards.json
@@ -1,6 +1,6 @@
 {
   "takaroVersion": "0.0.0",
-  "name": "Playtime Buff Rewards",
+  "name": "PlaytimeBuffRewards",
   "author": "El-Limon",
   "supportedGames": ["7 Days to Die", "Minecraft", "all"],
   "versions": [

--- a/public/modules/economy/ZombieRacing.json
+++ b/public/modules/economy/ZombieRacing.json
@@ -1,6 +1,6 @@
 {
   "takaroVersion": "0.0.0",
-  "name": "Zombie Racing",
+  "name": "ZombieRacing",
   "author": "Limon",
   "supportedGames": ["all"],
   "versions": [

--- a/utils/moduleLoader.test.ts
+++ b/utils/moduleLoader.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import { normalizeModules } from './moduleLoader';
 import { ModuleWithMeta } from '@/lib/types';
 
@@ -7,6 +9,47 @@ import { ModuleWithMeta } from '@/lib/types';
 // that can be tested in isolation
 
 describe('moduleLoader', () => {
+  describe('module naming conventions', () => {
+    it('keeps community module filenames and names URL lookup safe', () => {
+      const modulesDir = path.join(process.cwd(), 'public', 'modules');
+      const unsafePattern = /[^A-Za-z0-9_-]/;
+      const failures: string[] = [];
+
+      const scanDirectory = (dir: string) => {
+        for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+          const itemPath = path.join(dir, item.name);
+
+          if (item.isDirectory()) {
+            scanDirectory(itemPath);
+            continue;
+          }
+
+          if (!item.isFile() || !item.name.endsWith('.json')) {
+            continue;
+          }
+
+          const moduleData = JSON.parse(fs.readFileSync(itemPath, 'utf-8'));
+          const relativePath = path.relative(modulesDir, itemPath);
+          const filename = path.basename(item.name, '.json');
+
+          if (unsafePattern.test(filename)) {
+            failures.push(`${relativePath} has an unsafe filename`);
+          }
+
+          if (unsafePattern.test(moduleData.name)) {
+            failures.push(
+              `${relativePath} has unsafe name "${moduleData.name}"`,
+            );
+          }
+        }
+      };
+
+      scanDirectory(modulesDir);
+
+      expect(failures).toEqual([]);
+    });
+  });
+
   describe('normalizeModules', () => {
     it('should normalize modules with missing fields by providing defaults', () => {
       const moduleWithMissingFields: ModuleWithMeta = {


### PR DESCRIPTION
## Summary

Fixes module navigation for recent modules whose source `name` fields contained spaces. The viewer uses module names as URL lookup identifiers, and names with spaces can break click-through routing and changelog grouping. This renames the affected module identifiers to safe filename-aligned values while keeping the human-readable titles in each module description.

## What Changed

- **Module identifiers**: Updated `PlaytimeBuffRewards`, `ZombieRacing`, `referral-program`, and `community-fund` JSON `name` fields to remove spaces and match the repo naming convention.
- **Regression coverage**: Added a module-loader unit guard that scans community module JSON files and fails if either the filename or `name` field contains unsafe characters.

## Reviewer Guide

- **Start here**: `utils/moduleLoader.test.ts` for the new naming-convention guard.
- **Pay attention to**: the module JSON `name` fields, since these are lookup identifiers rather than display copy.
- **Design decision**: the fix preserves existing filenames and uses hyphen/camel-case names already established by those filenames, avoiding a routing fallback that would allow invalid source data to continue accumulating.

## Testing Plan

### Happy Path
- [ ] Open the viewer and search for `PlaytimeBuffRewards`.
- [ ] Click the module card and verify it opens `/module/PlaytimeBuffRewards/latest`.
- [ ] Repeat for `ZombieRacing`, `referral-program`, and `community-fund`.

### Edge Cases
- [ ] Add a temporary module JSON with a space in the `name` field and verify `npm run test:unit -- utils/moduleLoader.test.ts` catches it.
- [ ] Add a temporary module JSON filename with a space and verify the same test catches it.

### Regression Checks
- [ ] Run `npm run format:check`.
- [ ] Run `npm run test:unit -- utils/moduleLoader.test.ts`.
